### PR TITLE
Fix permissions problems by providing UID and GID environment variables.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,18 @@
 FROM selenium/standalone-chrome:latest
 
-ARG HOST_UID=1000
-ARG HOST_GID=1000
-
 USER root
-
-# Update and install requirements, then clean up.
-RUN apt-get update && \
-    apt-get install -y python3 python3-pip && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /downloads
 
 WORKDIR /app
 
 COPY requirements.txt .
- 
-RUN pip3 install --upgrade pip && \
-    pip3 install --no-cache-dir -r requirements.txt
+
+# Update and install requirements, then clean up.
+RUN apt-get update && \
+  apt-get install -y python3 python3-pip gosu && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  pip3 install --upgrade pip && \
+  pip3 install --no-cache-dir -r requirements.txt
 
 COPY *.py .
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ There is also a Dockerfile, which may be easier, git clone then build and run it
 git clone https://github.com/kernalbin/odmpy-ng.git
 cd odmpy-ng
 docker build -t odmpy-ng .
-docker run -it --rm -v ./config:/config -v ./downloads:/downloads odmpy-ng
+docker run -it --rm -v ./config:/config -v ./downloads:/downloads -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) odmpy-ng
 ```
 
 In either case you need to fill out a config file. 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,33 @@
-#!/bin/bash
+#!/bin/bash -x
 set -e
 
-# Run app
-python3 interactive.py /config/config.json
+# Set defaults if not provided
+: "${HOST_UID:=1000}"
+: "${HOST_GID:=1000}"
 
-# Set ownership of downloaded files
-chown -R ubuntu /downloads
+# Find existing group with the desired GID
+existing_group=$(getent group "$HOST_GID" | cut -d: -f1 || true)
+
+if [ -z "$existing_group" ]; then
+    groupadd -g "$HOST_GID" hostgroup
+    groupname=hostgroup
+else
+    groupname="$existing_group"
+fi
+
+existing_user=$(getent passwd "$HOST_UID" | cut -d: -f1 || true)
+if [ -z "$existing_user" ]; then
+    useradd -m -u "$HOST_UID" -g "$groupname" hostuser
+    username=hostuser
+else
+    username="$existing_user"
+fi
+
+# Fix permissions (optional, e.g., for /downloads)
+mkdir -p /downloads
+chown $HOST_UID:$HOST_GID /downloads
+chown -R $HOST_UID:$HOST_GID /app
+
+# Drop privileges
+exec gosu "$username" python3 interactive.py /config/config.json
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 set -e
 
 # Set defaults if not provided


### PR DESCRIPTION
Reorganize Dockerfile a bit; rewrite entrypoint.sh to look for environment variables provided on `docker run` line and run the command as that user using `gosu` command (which seems to be common practice, what would I know). Oh, and updated the readme.

Also handles the case where the host system uses the same user/group numbers as the original selenium system did (e.g. Ubuntu).