### PR TITLE
Save chapters, change name of metadata file.

### DIFF
--- a/interactive.py
+++ b/interactive.py
@@ -171,8 +171,10 @@ for title_index in title_selections:
             print("Downloaded Cover")
 
         if config.get("download_thunder_metadata", 0):
-            metadata_path = os.path.abspath(os.path.join(download_path, 'metadata.json'))
+            metadata_path = os.path.abspath(os.path.join(download_path, 'info.json'))
             if overdrive_download.downloadThunderMetadata(book_selection["id"], metadata_path):
+                with open(os.path.join(download_path,'chapters.json'), 'w') as f:
+                    json.dump(book_chapter_markers, f)
                 print("Downloaded additional metadata")
 
         if overdrive_download.downloadMP3(book_urls, tmp_dir, cookies):


### PR DESCRIPTION
My next goal is to use the chapter data to produce an audiobookshelf file (ABS), which will allow me to skip all of the encoding steps and just save the part-file.mp3s because ABS doesn't need any metadata in the audio.

But this is just a simple change for now: just save the chapters file (and also change the metadata file name so it doesn't sit where ABS's metadata file needs to be).