### PR TITLE
Fixed minor docker snafu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     pip3 install --no-cache-dir -r requirements.txt
 
 # Copy python scripts and entrypoint
-COPY *.py .
+COPY *.py ./
 COPY entrypoint.sh /entrypoint.sh
 
 # Make entrypoint executable


### PR DESCRIPTION
without this it won't even build in my system

> 
> Step 6/9 : COPY *.py .
> When using COPY with more than one source file, the destination must be a directory and end with a /