### PR TITLE
Seek chapters, then use 1-min and 15-s skips to narrow down.

### DIFF
--- a/convert_metadata.py
+++ b/convert_metadata.py
@@ -396,7 +396,7 @@ def convert_file(filename: str, total_duration: str):
         if chapters:
             chapters[-1]['end'] = total_seconds
 
-    output_data = abs_from_pylibby(input_data, ["PyLibbyNG"])
+    output_data = abs_from_pylibby(input_data, ["OdmpyNG"])
     if chapters:
         output_data['chapters'] = chapters
 

--- a/scraper.py
+++ b/scraper.py
@@ -155,6 +155,11 @@ class Scraper:
 
         return books
     
+    def has_url(self, part_num) -> bool:
+        mp3_urls = self.requests_to_mp3_files()
+        url = mp3_urls.get(f"{part_num:02d}")
+        return url is not None
+
     def requests_to_mp3_files(self) -> dict:
         """
         Extracts MP3 file URLs from the browser's request history.
@@ -171,6 +176,14 @@ class Scraper:
                     if part_id not in urls:
                         urls[part_id] = request.url
         return urls
+
+    def assess_chapter(self, chapter_seconds, current_location) -> int:
+        # Don't enumerate the last element, it's actually the end of the book.
+        for i, start in enumerate(chapter_seconds[:-1]):
+            if current_location >= start and current_location < chapter_seconds[i+1]:
+                return i
+        # Account for the end of the book.
+        return len(chapter_seconds) - 2
     
     def extract_minutes_to_seconds(self, raw_text: str):
         """
@@ -226,10 +239,12 @@ class Scraper:
 
 
         chapter_times = []
+        chapter_seconds = []
 
         for elem in chapter_time_elements:
             if elem.text:
                 chapter_times.append(elem.text)
+                chapter_seconds.append(convert_metadata.to_seconds(elem.text))
 
         for index, title in enumerate(chapter_title_elements):
             chapter_markers[title.text] = chapter_times[index]
@@ -255,67 +270,108 @@ class Scraper:
         print("Getting files")
 
         mp3_urls = self.requests_to_mp3_files()
-        total_duration = 0
+        loaded_duration = 0
         current_location = 0
         part_num = 1
         expected_duration = convert_metadata.to_seconds(expected_time)
-        missing_flag = False
+        chapter_seconds.append(expected_duration)
 
         # Main loop for walking through book
         while True:
-            current_location = convert_metadata.to_seconds(timeline_current_time.get_attribute("textContent"))
-
-            # Skip to end of previously downloaded segment
-            while current_location < total_duration:
-
-                if not missing_flag:
-                    # Check if chapter is shorter than where the next part starts, and if so, can skip the whole chapter
-                    next_chapter_seconds = self.extract_minutes_to_seconds(chapter_next.get_attribute("textContent"))
-                    if total_duration-current_location > next_chapter_seconds:
-                        chapter_next.click()
-                        # print(f"Skipped chapter - {next_chapter_seconds} seconds")
-                        time.sleep(.5)
-                        current_location = convert_metadata.to_seconds(timeline_current_time.get_attribute("textContent"))
-
-                # # Jump by 15 seconds until we reach the end of the part
-                # time_next.click()
-
-                # Jump by 1 minute using page_down
-                self.driver.find_element(By.TAG_NAME, "body").send_keys(Keys.PAGE_DOWN)
-                current_location = convert_metadata.to_seconds(timeline_current_time.get_attribute("textContent"))
-
-            # Collect available urls, and download next part
+            # Collect available urls, and download next part; this also detects
+            # loop end when audio is complete.
             mp3_urls = self.requests_to_mp3_files()
-
             url = mp3_urls.get(f"{part_num:02d}")
-            if not url:
-                print(f"Missing part {part_num}")
-                print("Trying to go back")
-                try:
-                    chapter_previous.click()
-                except ElementClickInterceptedException:
-                    print("Unable to skip to last chapter")
-                    
-                missing_flag = True
-                continue
+            if url:
+                length = overdrive_download.download_mp3_part(url, f"{part_num:02d}", download_path, self.get_cookies())
+                # If valid download, add the length of the part to the total, check progress through whole book
+                if length:
+                    loaded_duration += length
+                    print(f"{loaded_duration:.2f}/{expected_duration:.2f} sec  -  {loaded_duration/expected_duration*100:.2f}%")
+                    if loaded_duration >= expected_duration-1:
+                        print("Downloaded complete audio")
+                        print(f"Book contained {part_num} part(s)")
+                        break
+                    part_num += 1
+                    continue
+                else:
+                    print(f"Download failed for part {part_num}")
+                    sys.exit(3)
 
-            length = overdrive_download.download_mp3_part(url, f"{part_num:02d}", download_path, self.get_cookies())
+            # Begin search for the absent part.
+            lower_bound = int(loaded_duration)
+            upper_bound = int(min(loaded_duration + 30*60, expected_duration)) # 30 minutes
+            print(f"Missing part {part_num} between ({lower_bound}, {upper_bound}) sec")
+            while not self.has_url(part_num):
+                current_location = convert_metadata.to_seconds(timeline_current_time.get_attribute("textContent"))
+                # First, see if there's a chapter mark that divides our range.
+                desired_chapter = self.assess_chapter(chapter_seconds, upper_bound)
+                desired_chapter_start = chapter_seconds[desired_chapter]
+                current_chapter = self.assess_chapter(chapter_seconds, current_location)
+                current_chapter_start = chapter_seconds[current_chapter]
+                if desired_chapter_start >= lower_bound and desired_chapter_start != current_location:
+                    offset = current_location - current_chapter_start
+                    print(f"Skipping from chapter {current_chapter} + {offset}s to {desired_chapter}.")
+                    if desired_chapter <= current_chapter:
+                        if offset:
+                            # Chapter markers are at the beginning, so going backward might take one extra click.
+                            chapter_previous.click()
+                            time.sleep(1)
+                        while desired_chapter < current_chapter:
+                            chapter_previous.click()
+                            time.sleep(1)
+                            current_chapter -= 1
+                    else:
+                        while desired_chapter > current_chapter:
+                            chapter_next.click()
+                            time.sleep(1)
+                            current_chapter += 1
+                    current_location = convert_metadata.to_seconds(timeline_current_time.get_attribute("textContent"))
+                    if current_location != desired_chapter_start:
+                        current_chapter = self.assess_chapter(chapter_seconds, current_location)
+                        current_chapter_start = chapter_seconds[current_chapter]
+                        raise Exception(f"failed to find start of chapter {desired_chapter}, actually ch{current_chapter} + {current_location - current_chapter_start}")
+                    # If there's an internal split, it gives us a new upper bound.
+                    if lower_bound < current_location <= upper_bound:
+                        upper_bound = current_location - 1
+                if self.has_url(part_num):
+                    continue
+                # Next, try to use the minute-skip key to get into the range.
+                body = self.driver.find_element(By.TAG_NAME, "body")
+                while current_location <= lower_bound and current_location <= upper_bound-60 and not self.has_url(part_num):
+                    # ffwd into the range if you can, without going past it.
+                    body.send_keys(Keys.PAGE_DOWN)
+                    time.sleep(.5)
+                    current_location = convert_metadata.to_seconds(timeline_current_time.get_attribute("textContent"))
+                while current_location-60 > lower_bound and not self.has_url(part_num):
+                    # frewind back to near the start of the range, without going past it.
+                    body.send_keys(Keys.PAGE_UP)
+                    time.sleep(.5)
+                    current_location = convert_metadata.to_seconds(timeline_current_time.get_attribute("textContent"))
+                if self.has_url(part_num):
+                    # Shortcut if we're done.
+                    continue
+                if lower_bound < current_location <= upper_bound:
+                    # If the range was split, ignore the upper half.
+                    upper_bound = current_location - 1
+                # Next, try to use the small-skip key to get into the new range.
+                while current_location <= lower_bound and current_location <= upper_bound-15 and not self.has_url(part_num):
+                    # fwd into the range if you can, without going past it.
+                    body.send_keys(Keys.ARROW_RIGHT)
+                    time.sleep(.5)
+                    current_location = convert_metadata.to_seconds(timeline_current_time.get_attribute("textContent"))
+                while current_location-15 > lower_bound and not self.has_url(part_num):
+                    # rewind back to near the start of the range, without going past it.
+                    body.send_keys(Keys.ARROW_LEFT)
+                    time.sleep(.5)
+                    current_location = convert_metadata.to_seconds(timeline_current_time.get_attribute("textContent"))
+                if self.has_url(part_num):
+                    continue
+                if lower_bound < current_location <= upper_bound:
+                    # If the range was split, ignore the upper half.
+                    upper_bound = current_location - 1
+                raise Exception(f"Need more precise search for {upper_bound - lower_bound}s range between {lower_bound}, {upper_bound}")
 
-            # If valid download, add the length of the part to the total, check progress through whole book
-            if length:
-                total_duration += length
-                print(f"{total_duration:.2f}/{expected_duration:.2f} sec  -  {total_duration/expected_duration*100:.2f}%")
-                if total_duration >= expected_duration-1:
-                    print("Downloaded complete audio")
-                    print(f"Book contained {part_num} part(s)")
-                    break
-                part_num += 1
-                missing_flag = False
-            else:
-                print(f"Download failed for part {part_num}")
-                sys.exit(3)
-
-        
         # Attempt to find and save cover image
         cover_image_url = next(
             (req.url for req in self.driver.requests if req.response and '.jpg' in req.url and 'listen.overdrive.com' in req.url),


### PR DESCRIPTION
This is improved; it uses the current position to seek for the new one, and uses the idea of a range of plausible locations to narrow down where the missing part might be.

1. very small chapters will still often kill it, 15 seconds is the smallest skip I can do and the example in my bug report has a 12s chapter (!) that is its own part. I did test this against several other books, that's naturally rare. Even when it happens it'll sometimes not matter if the chapter marks align right to allow the 1m or 15s skip to land right in the middle.
2. skipping many chapters would be faster by popping down the chapter menu - it takes ~1sec per chapter otherwise. I guess that's not a fail per se.

It's probably mergeable even with point 1 as a problem. Maybe look at my exception printout and word it better, dunno. It's still better than it was. The challenge is that to do better, we need some way to scan such tiny areas; the only thing I can think of is lining up as close as we can get and hitting Play.