### PR TITLE
Use table of contents to massively accelerate search

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -348,7 +348,7 @@ class Scraper:
                     offset = current_location - current_chapter_start
                     low, high = sorted([current_chapter, desired_chapter])
                     span = desired_chapter_start - current_location
-                    print(f"Skipping from chapter {current_chapter} + {offset}s to {desired_chapter}, span {span}s. Chs: {self.chapter_seconds[low:high+1]}")
+                    print(f"Skipping from chapter {current_chapter} + {offset}s to {desired_chapter}/{len(self.chapter_seconds)-1}, span {span}s. Chs: {self.chapter_seconds[low:high+1]}")
 
                     chapter_table_open.click()
                     time.sleep(1)


### PR DESCRIPTION
Same code as before mostly, but scary fast per chapter (at the cost of a slightly slower startup, currently using 0.5s / chapter to read the chapter info, maybe I could lower the time I'm waiting for skip-chapter but it's hard to be sure about that kind of thing).