### PR TITLE
Add command line option support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,8 @@ RUN chmod +x /entrypoint.sh
 # Supress pkg_resources deprecation warning until upstream resolves
 ENV PYTHONWARNINGS="ignore:pkg_resources is deprecated as an API"
 
-# default command to run the app
-CMD ["/entrypoint.sh"]
+# command to run the app (will accept arguments)
+ENTRYPOINT ["/entrypoint.sh"]
+# default arguments to pass to the entrypoint
+CMD []
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,11 +23,11 @@ else
     username="$existing_user"
 fi
 
-# Fix permissions (optional, e.g., for /downloads)
+# Fix permissions
 mkdir -p /downloads
 chown $HOST_UID:$HOST_GID /downloads
 chown -R $HOST_UID:$HOST_GID /app
 
 # Drop privileges
-exec gosu "$username" python3 interactive.py /config/config.json
+exec gosu "$username" python3 interactive.py /config/config.json "$@"
 


### PR DESCRIPTION
Add command line options to preselect which library to go to, and which Libby ID to choose from it. (Both are completely optional, omit either CLI option and you'll be prompted for which choice).

Modify the title display to include Libby IDs. (You can get those IDs a lot faster from the old `odmpy libby`.