### PR TITLE
Permit restart, also keeps the source code out of the Docker to improve coding speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ RUN apt-get update && \
     pip3 install --upgrade pip && \
     pip3 install --no-cache-dir -r requirements.txt
 
-# Copy python scripts and entrypoint
-COPY *.py ./
+# Copy entrypoint
 COPY entrypoint.sh /entrypoint.sh
 
 # Make entrypoint executable

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,8 @@ RUN chmod +x /entrypoint.sh
 # Supress pkg_resources deprecation warning until upstream resolves
 ENV PYTHONWARNINGS="ignore:pkg_resources is deprecated as an API"
 
-# default command to run the app
-CMD ["/entrypoint.sh"]
+# command to run the app (will accept arguments)
+ENTRYPOINT ["/entrypoint.sh"]
+# default arguments to pass to the entrypoint
+CMD []
+

--- a/convert_metadata.py
+++ b/convert_metadata.py
@@ -18,14 +18,14 @@ def get_mp3_duration(filepath):
     """Returns the duration of an MP3 file in seconds."""
     return MP3(filepath).info.length
 
-def get_total_duration(directory):
+def get_total_duration(directory) -> int:
     """Calculates the total duration of all MP3 files in a directory."""
     total_duration = 0
     for filename in os.listdir(directory):
         if filename.endswith(".mp3"):
             filepath = os.path.join(directory, filename)
             total_duration += get_mp3_duration(filepath)
-    return total_duration
+    return int(total_duration)
 
 def abs_from_pylibby(container, mark_autoloaded=["Misordered"]):
     # pylibby uses two different formats, not sure why.
@@ -360,6 +360,12 @@ communities = {
 def to_seconds(hms: str) -> int:
     parts = list(map(int, hms.split(":")))
     return sum(x * 60**i for i, x in enumerate(reversed(parts)))
+
+def to_hms(seconds: int) -> str:
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    seconds = seconds % 60
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
 
 def main():
     if len(sys.argv) != 3:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,11 +23,11 @@ else
     username="$existing_user"
 fi
 
-# Fix permissions (optional, e.g., for /downloads)
+# Fix permissions
 mkdir -p /downloads
 chown $HOST_UID:$HOST_GID /downloads
 chown -R $HOST_UID:$HOST_GID /app
 
 # Drop privileges
-exec gosu "$username" python3 interactive.py /config/config.json
+exec gosu "$username" python3 interactive.py /config/config.json "$@"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,6 @@ fi
 # Fix permissions
 mkdir -p /downloads
 chown $HOST_UID:$HOST_GID /downloads
-chown -R $HOST_UID:$HOST_GID /app
 
 # Drop privileges
 exec gosu "$username" python3 interactive.py /config/config.json "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ h2>=4.2.0
 hpack>=4.1.0
 hyperframe>=6.1.0
 idna>=3.10
+atomicwrites>=1.4.1
 kaitaistruct>=0.10
 mutagen>=1.47.0
 outcome>=1.3.0.post0


### PR DESCRIPTION
The main purpose of this was to make editing code faster, since you never have to run docker build you also never suffer from FORGETTING to run it.

But as a user-visible side effect, it also allows resuming downloads - because the tmp folder can no longer be kept on the source file folder (it's read-only now), if your connection fails (I see this happening several times with a timeout), you just run the same command but add the -r flag, and it nicely resumes for you.

...of course we should also handle the timeout. But this is the easy solution.