### PR TITLE
Support for Sublibraries - when overdrive asks you which library to use before login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Lib/
 Inclue/
 downloads/
 lib/
+bin/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Example `config.json`:
             "name": "Example Library",
             "url": "https://yourlibrary.overdrive.com",
             "card_number": "YOUR_CARD_NUMBER",
-            "pin": "YOUR_PIN"
+            "pin": "YOUR_PIN",
+            "sublibrary": "Your Sublibrary"
         }
     ],
     "low_quality_encode": 0,
@@ -111,9 +112,16 @@ Example `config.json`:
 }
 ```
 
+The "sublibrary" key will be needed if your library's site is a cooperative;
+you can find what to enter here by logging into your OverDrive site, libraries
+that need this will first ask you to select a sublibrary from a dropdown list.
+Just enter the name of the sublibrary you click on here. If your library doesn't
+have a sublibrary, you can leave this key out, it'll be ignored.
+
 Optionally, each library may have a "site-id" key with an integer value, which
 may be passed to the -s option to skip past the library selection screen. Any
-site-id values provided must be unique within your configuration file.
+site-id values provided must be unique within your configuration file. See the
+provided `config.example.json` file for an example.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ Example `config.json`:
 }
 ```
 
-The "sublibrary" key will be needed if your library's site is a cooperative;
-you can find what to enter here by logging into your OverDrive site, libraries
-that need this will first ask you to select a sublibrary from a dropdown list.
-Just enter the name of the sublibrary you click on here. If your library doesn't
-have a sublibrary, you can leave this key out, it'll be ignored.
+Optionally, the "sublibrary" key will speed things up if your library's site is
+a cooperative; if you don't provide this, odmpy-ng will prompt you for it,
+listing all of the choices. Just enter the name of the sublibrary you
+recognize. If your library doesn't have a sublibrary, you can leave this key
+out, it'll be ignored.
 
 Optionally, each library may have a "site-id" key with an integer value, which
 may be passed to the -s option to skip past the library selection screen. Any

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -2,10 +2,11 @@
     "libraries": [
         {
             "name": "Example Library",
-            "url": "https://yourlibrary.overdrive.com",
+            "url": "https://yourlibrary-sublibrary.overdrive.com",
             "card_number": "YOUR_CARD_NUMBER",
             "pin": "YOUR_PIN",
-            "site-id": 103
+            "site-id": 103,
+            "sublibrary": "Your Sublibrary"
         }
     ],
     "low_quality_encode": 0,

--- a/convert_metadata.py
+++ b/convert_metadata.py
@@ -372,19 +372,16 @@ def to_hms(seconds: int) -> str:
     return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
 
 def main():
-    if len(sys.argv) != 3:
-        print("Usage: python transform_json.py <ifilename> <total_duration>")
+    if len(sys.argv) != 2:
+        print("Usage: python transform_json.py <ifilename>")
         sys.exit(1)
 
     filename = sys.argv[1]
-    total_duration = sys.argv[2]
-    convert_file(filename, total_duration)
+    convert_file(filename)
 
-def convert_file(filename: str, total_duration: str):
+def convert_file(filename: str):
     dir, _ = os.path.split(filename)
     ofilename = os.path.join(dir, 'metadata.json')
-
-    total_seconds = to_seconds(total_duration)
 
     with open(filename, 'r') as file:
         data = json.load(file)
@@ -396,15 +393,12 @@ def convert_file(filename: str, total_duration: str):
     if os.path.exists(chapter_file):
         # Convert to a audiobookfile chapter list.
         with open(chapter_file) as f:
-            raw = json.load(f)
-        # Apparently Overdrive indexes by chapter NAME, switch to a list of chapter starts.
-        chs = sorted((to_seconds(time), title) for title,time in raw.items())
+            chs = json.load(f)
         for i, ch in enumerate(chs):
-            if chapters:
-                chapters[-1]['end'] = ch[0]
-            chapters.append({'id': i, 'title': ch[1], 'start': ch[0]})
-        if chapters:
-            chapters[-1]['end'] = total_seconds
+            title, start, end = ch
+            if not title:
+                title = ''
+            chapters.append({'id': i, 'title': title, 'start': start, 'end': end})
 
     output_data = abs_from_pylibby(input_data, ["Autoloaded", "OdmpyNG"])
     if chapters:

--- a/interactive.py
+++ b/interactive.py
@@ -233,16 +233,15 @@ def main():
         print(f"Accessing {book_selection['title']}, ID: {book_selection['id']}")
 
         # Use scraper.py to download book
-        book_data = scraper.get_book(book_selection["link"], tmp_dir)
+        book_chapter_markers = scraper.get_book(book_selection["link"], tmp_dir)
 
-        if not book_data:
+        if not book_chapter_markers:
             print("Failed to download")
             continue
 
         # Reformat returned tuple for easier readability
         book_title = book_selection["title"]
         book_author = book_selection["author"]
-        book_chapter_markers, book_expected_length = book_data
 
         # Save current cookies for upcoming downloads
         cookies = scraper.get_cookies()
@@ -269,7 +268,7 @@ def main():
             if overdrive_download.download_thunder_metadata(book_selection["id"], metadata_path):
                 print("Downloaded json metadata")
                 if config.get("convert_audiobookshelf_metadata", 0):
-                    convert_metadata.convert_file(metadata_path, book_expected_length)
+                    convert_metadata.convert_file(metadata_path)
                     print("Provided audiobookshelf metadata")
                     if not config.get("download_thunder_metadata", 0):
                         os.unlink(metadata_path)
@@ -289,7 +288,7 @@ def main():
                 print("Converted to single M4B")
 
             print("Generating metadata")
-            ffmetadata.write_metafile(tmp_dir, book_chapter_markers, book_title, book_author, book_expected_length)
+            ffmetadata.write_metafile(tmp_dir, book_chapter_markers, book_title, book_author)
 
             print("Adding metadata to audiobook")
             cover_path = os.path.abspath(os.path.join(tmp_dir, "cover.jpg"))

--- a/scraper.py
+++ b/scraper.py
@@ -109,13 +109,18 @@ class Scraper:
             time.sleep(0.25)
             subs = sublibrary_output.find_elements(By.TAG_NAME, 'li')
             # Display numbered list of sublibraries and prompt for selection
+            idx = None if interactive else find_biggest_match_index(self.config['sublibrary'], [sub.text for sub in subs])
             for index,sub in enumerate(subs):
-                print(f"   {index}: {sub.text}")
+                selector = ""
+                if idx is None:
+                    selector = f'{index:>2}'
+                elif index == idx:
+                    selector = '->'
+                print(f" {selector:>2}: {sub.text}")
             if interactive:
                 sub_index = int(input("Select sublibrary: "))
                 subs[sub_index].click()
             else:
-                idx = find_biggest_match_index(self.config['sublibrary'], [sub.text for sub in subs])
                 if idx is None:
                     print(f"ERROR: Sublibrary {self.config['sublibrary']} not found in library {self.config['library']}")
                     sys.exit(2)

--- a/scraper.py
+++ b/scraper.py
@@ -77,29 +77,35 @@ class Scraper:
 
         # Logins with sublibrary sometimes require choosing it first.
         if sublibrary_input and sublibrary_input.is_displayed() and sublibrary_input.is_enabled():
-            if not self.config['sublibrary']:
-                print(f"ERROR: Sublibrary required for library {self.config['library']} but not specified")
-                sys.exit(2)
+            interactive = not self.config.get('sublibrary')
             sublibrary_input.click()
             time.sleep(0.25)
             sublibrary_output = self.driver.find_element(By.CLASS_NAME, 'ui-autocomplete')
             print(f"Starting with {len(sublibrary_output.find_elements(By.TAG_NAME, 'li'))} sublibrary options.")
-            # Type one key at a time until selection list reduces to a single option
-            for char in self.config['sublibrary']:
-                sublibrary_input.send_keys(char)
-                time.sleep(0.25)
+            if interactive:
                 subs = sublibrary_output.find_elements(By.TAG_NAME, 'li')
-                print(f"   after typing '{char}': {len(subs)} options.")
-                # If only one ul item left, select it
-                if len(subs) == 1:
-                    sublibrary_output = self.driver.find_element(By.CLASS_NAME, 'ui-autocomplete')
+                # Display numbered list of sublibraries and prompt for selection
+                for index,sub in enumerate(subs):
+                    print(f"   {index}: {sub.text}")
+                sub_index = int(input("Select sublibrary: "))
+                subs[sub_index].click()
+            else:
+                # Type one key at a time until selection list reduces to a single option
+                for char in self.config['sublibrary']:
+                    sublibrary_input.send_keys(char)
+                    time.sleep(0.1)
                     subs = sublibrary_output.find_elements(By.TAG_NAME, 'li')
-                    subs[0].click()
-                    time.sleep(0.25)
-                    break
-                elif not subs:
-                    print(f"ERROR: Sublibrary {self.config['sublibrary']} not found in library {self.config['library']}")
-                    sys.exit(2)
+                    print(f"   after typing '{char}': {len(subs)} options.")
+                    # If only one ul item left, select it
+                    if len(subs) == 1:
+                        sublibrary_output = self.driver.find_element(By.CLASS_NAME, 'ui-autocomplete')
+                        subs = sublibrary_output.find_elements(By.TAG_NAME, 'li')
+                        subs[0].click()
+                        time.sleep(0.25)
+                        break
+                    elif not subs:
+                        print(f"ERROR: Sublibrary {self.config['sublibrary']} not found in library {self.config['library']}")
+                        sys.exit(2)
 
         signin_button = self.driver.find_element(By.CLASS_NAME, 'signin-button')
 


### PR DESCRIPTION
This should work the same for normal libraries as it did before, but when a library has sublibraries, it will automatically display a selection list to allow the user to choose which one.

In addition, you can skip this selection list by adding a `sublibrary` key to your config for the library in question. It'll perform a substring search on the library list, so all you have to type here is just enough to uniquely find a single item on the list.
```json
"sublibrary": "My Sublibrary"
```